### PR TITLE
feat: add grey dilation and erosion operators

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -176,4 +176,37 @@ def test_grey_erode():
 	assert np.all(out == 0)
 
 
+def test_grey_dilate():
+	L = 100
+	H = 200
+
+	labels = np.zeros((3,3,3), dtype=int)
+	labels[0,0,0] = L
+	labels[2,2,2] = H
+
+	out = fastmorph.dilate(labels, mode=fastmorph.Mode.grey)
+
+	ans = np.array([
+		[
+			[L, L, 0],
+			[L, L, 0],
+			[0, 0, 0],
+		],
+		[
+			[L, L, 0],
+			[L, H, H],
+			[0, H, H],
+		],
+		[
+			[0, 0, 0],
+			[0, H, H],
+			[0, H, H],
+		],
+	]).T
+
+	assert np.all(out == ans)
+
+	out = fastmorph.dilate(out, mode=fastmorph.Mode.grey)
+	assert np.all(out == H)
+
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -77,7 +77,7 @@ def test_spherical_close():
 	assert res[5,5,5] == True
 
 
-def test_dilate():
+def test_multilabel_dilate():
 	labels = np.zeros((3,3,3), dtype=bool)
 
 	out = fastmorph.dilate(labels)
@@ -117,7 +117,7 @@ def test_dilate():
 	assert np.all(ans == out)
 
 
-def test_erode():
+def test_multilabel_erode():
 	labels = np.ones((3,3,3), dtype=bool)
 	out = fastmorph.erode(labels)
 	assert np.sum(out) == 1 and out[1,1,1] == True
@@ -146,6 +146,34 @@ def test_erode():
 	labels = np.ones((5,5,5), dtype=bool)
 	out = fastmorph.erode(labels)
 	assert np.sum(out) == 27
+
+
+def test_grey_erode():
+	labels = np.arange(27, dtype=int).reshape((3,3,3), order="F")
+	out = fastmorph.erode(labels, mode=fastmorph.Mode.grey)
+
+	ans = np.array([
+		[
+			[0, 0, 1],
+			[0, 0, 1],
+			[3, 3, 4],
+		],
+		[
+			[0, 0, 1],
+			[0, 0, 1],
+			[3, 3, 4],
+		],
+		[
+			[9, 9, 10],
+			[9, 9, 10],
+			[12, 12, 13],
+		],
+	]).T
+
+	assert np.all(out == ans)
+
+	out = fastmorph.erode(out, mode=fastmorph.Mode.grey)
+	assert np.all(out == 0)
 
 
 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -43,7 +43,10 @@ def dilate(
   labels = np.asfortranarray(labels)
   while labels.ndim < 3:
     labels = labels[..., np.newaxis]
-  output = fastmorphops.dilate(labels, background_only, parallel)
+  if mode == Mode.multilabel:
+    output = fastmorphops.multilabel_dilate(labels, background_only, parallel)
+  else:
+    output = fastmorphops.grey_dilate(labels, parallel)
   return output.view(labels.dtype)
 
 def erode(
@@ -76,6 +79,7 @@ def opening(
   labels:np.ndarray, 
   background_only:bool = True,
   parallel:int = 1,
+  mode:Mode = Mode.multilabel,
 ) -> np.ndarray:
   """Performs morphological opening of labels.
 
@@ -84,11 +88,12 @@ def opening(
     False: Allow labels to erode each other as they grow.
   parallel: how many pthreads to use in a threadpool
   """
-  return dilate(erode(labels, parallel), background_only, parallel)
+  return dilate(erode(labels, parallel, mode), background_only, parallel, mode)
 
 def closing(
   labels:np.ndarray, 
   background_only:bool = True,
+  mode:Mode = Mode.multilabel,
 ) -> np.ndarray:
   """Performs morphological closing of labels.
 
@@ -97,7 +102,7 @@ def closing(
     False: Allow labels to erode each other as they grow.
   parallel: how many pthreads to use in a threadpool
   """
-  return erode(dilate(labels, background_only, parallel), parallel)
+  return erode(dilate(labels, background_only, parallel, mode), parallel, mode)
 
 def spherical_dilate(
   labels:np.ndarray, 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Optional, Sequence
 import numpy as np
 import edt
@@ -10,10 +11,15 @@ import fastmorphops
 
 AnisotropyType = Optional[Sequence[int]]
 
+class Mode(Enum):
+  multilabel = 1
+  grey = 2
+
 def dilate(
   labels:np.ndarray,
   background_only:bool = True,
   parallel:int = 1,
+  mode:Mode = Mode.multilabel,
 ) -> np.ndarray:
   """
   Dilate forground labels using a 3x3x3 stencil with
@@ -40,7 +46,11 @@ def dilate(
   output = fastmorphops.dilate(labels, background_only, parallel)
   return output.view(labels.dtype)
 
-def erode(labels:np.ndarray, parallel:int = 1) -> np.ndarray:
+def erode(
+  labels:np.ndarray, 
+  parallel:int = 1,
+  mode:Mode = Mode.multilabel,
+) -> np.ndarray:
   """
   Erodes forground labels using a 3x3x3 stencil with
   all elements "on".
@@ -55,7 +65,11 @@ def erode(labels:np.ndarray, parallel:int = 1) -> np.ndarray:
   labels = np.asfortranarray(labels)
   while labels.ndim < 3:
     labels = labels[..., np.newaxis]
-  output = fastmorphops.erode(labels, parallel)
+
+  if mode == Mode.multilabel:
+    output = fastmorphops.multilabel_erode(labels, parallel)
+  else:
+    output = fastmorphops.grey_erode(labels, parallel)
   return output.view(labels.dtype)
 
 def opening(

--- a/fastmorph/fastmorphops.cpp
+++ b/fastmorph/fastmorphops.cpp
@@ -34,7 +34,7 @@ py::array to_numpy(
 }
 
 // assumes fortran order
-py::array dilate(
+py::array multilabel_dilate(
 	const py::array &labels, 
 	const bool background_only, 
 	const int threads
@@ -76,7 +76,7 @@ py::array dilate(
 }
 
 // assumes fortran order
-py::array erode(const py::array &labels, const uint64_t threads) {
+py::array multilabel_erode(const py::array &labels, const uint64_t threads) {
 	int width = labels.dtype().itemsize();
 
 	const uint64_t sx = labels.shape()[0];
@@ -112,8 +112,47 @@ py::array erode(const py::array &labels, const uint64_t threads) {
 #undef ERODE_HELPER
 }
 
+
+// assumes fortran order
+py::array grey_erode(const py::array &labels, const uint64_t threads) {
+	int width = labels.dtype().itemsize();
+
+	const uint64_t sx = labels.shape()[0];
+	const uint64_t sy = labels.shape()[1];
+	const uint64_t sz = labels.shape()[2];
+
+	void* labels_ptr = const_cast<void*>(labels.data());
+	uint8_t* output_ptr = new uint8_t[sx * sy * sz * width]();
+
+	py::array output;
+
+#define GREY_ERODE_HELPER(int_t)\
+	fastmorph::grey_erode(\
+		reinterpret_cast<int_t*>(labels_ptr),\
+		reinterpret_cast<int_t*>(output_ptr),\
+		sx, sy, sz,\
+		threads\
+	);\
+	return to_numpy(reinterpret_cast<int_t*>(output_ptr), sx, sy, sz);
+
+	if (width == 1) {
+		GREY_ERODE_HELPER(uint8_t)
+	}
+	else if (width == 2) {
+		GREY_ERODE_HELPER(uint16_t)
+	}
+	else if (width == 4) {
+		GREY_ERODE_HELPER(uint32_t)
+	}
+	else {
+		GREY_ERODE_HELPER(uint64_t)
+	}
+#undef GREY_ERODE_HELPER
+}
+
 PYBIND11_MODULE(fastmorphops, m) {
 	m.doc() = "Accelerated fastmorph functions."; 
 	m.def("dilate", &dilate, "Morphological dilation of a multilabel volume using a 3x3x3 structuring element.");
-	m.def("erode", &erode, "Morphological erosion of a multilabel volume using a 3x3x3 structuring element.");
+	m.def("multilabel_erode", &multilabel_erode, "Morphological erosion of a multilabel volume using mode of a 3x3x3 structuring element.");
+	m.def("grey_erode", &grey_erode, "Morphological erosion of a grayscale volume using min of a 3x3x3 structuring element.");
 }


### PR DESCRIPTION
Did all this work for multi-label, why not add grayscale as well (spelled as the British English "grey" to harmonize with SciPy and Scikit-Image, what a headache that would be if they didn't agree!).

I decided to go with an enum for selecting the mode. Multi-label is the default. You can select grey with `mode=fastmorph.Mode.grey`.