### PR TITLE
feat: 2D operations for multilabel dilate and erode + fix

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -220,6 +220,19 @@ def test_multilabel_erode_2d():
 	np.int8,np.int16,np.int32,np.int64,
 ])
 def test_grey_erode(dtype):
+	labels = np.arange(9, dtype=dtype).reshape((3,3), order="F")
+	out = fastmorph.erode(labels, mode=fastmorph.Mode.grey)
+
+	ans = np.array([
+		[0, 0, 1],
+		[0, 0, 1],
+		[3, 3, 4],
+	], dtype=dtype).T
+	assert np.all(out == ans)
+
+	out = fastmorph.erode(out, mode=fastmorph.Mode.grey)
+	assert np.all(out == 0)
+
 	labels = np.arange(27, dtype=dtype).reshape((3,3,3), order="F")
 	out = fastmorph.erode(labels, mode=fastmorph.Mode.grey)
 
@@ -254,6 +267,20 @@ def test_grey_dilate(dtype):
 	L = 5
 	H = 10
 
+	labels = np.zeros((3,3), dtype=dtype)
+	labels[0,0] = L
+	labels[2,2] = H
+
+	out = fastmorph.dilate(labels, mode=fastmorph.Mode.grey)
+
+	ans = np.array([
+		[L, L, 0],
+		[L, H, H],
+		[0, H, H],
+	], dtype=dtype).T
+
+	assert np.all(out == ans)
+
 	labels = np.zeros((3,3,3), dtype=dtype)
 	labels[0,0,0] = L
 	labels[2,2,2] = H
@@ -286,6 +313,12 @@ def test_grey_dilate(dtype):
 def test_grey_dilate_bool():
 	labels = np.zeros((3,3,3), dtype=bool)
 	labels[1,1,1] = True
+
+	out = fastmorph.dilate(labels, mode=fastmorph.Mode.grey)
+	assert np.all(out == True)
+
+	labels = np.zeros((3,3), dtype=bool)
+	labels[1,1] = True
 
 	out = fastmorph.dilate(labels, mode=fastmorph.Mode.grey)
 	assert np.all(out == True)

--- a/automated_test.py
+++ b/automated_test.py
@@ -77,7 +77,7 @@ def test_spherical_close():
 	assert res[5,5,5] == True
 
 
-def test_multilabel_dilate():
+def test_multilabel_dilate_3d():
 	labels = np.zeros((3,3,3), dtype=bool)
 
 	out = fastmorph.dilate(labels)
@@ -116,8 +116,46 @@ def test_multilabel_dilate():
 	ans[1:,:,:] = 2
 	assert np.all(ans == out)
 
+def test_multilabel_dilate_2d():
+	labels = np.zeros((3,3), dtype=bool)
 
-def test_multilabel_erode():
+	out = fastmorph.dilate(labels)
+	assert not np.any(out)
+
+	labels[1,1] = True
+
+	out = fastmorph.dilate(labels)
+	assert np.all(out)
+
+	labels = np.zeros((3,3), dtype=bool)
+	labels[0,0] = True
+	out = fastmorph.dilate(labels)
+
+	ans = np.zeros((3,3), dtype=bool)
+	ans[:2,:2] = True
+
+	assert np.all(out == ans)
+
+	labels = np.zeros((3,3), dtype=int)
+	labels[0,1] = 1
+	labels[2,1] = 2
+
+	out = fastmorph.dilate(labels)
+	ans = np.ones((3,3), dtype=int)
+	ans[2,:] = 2
+	assert np.all(ans == out)
+
+	labels = np.zeros((3,3), dtype=int, order="F")
+	labels[0,1] = 1
+	labels[1,1] = 2
+	labels[2,1] = 2
+
+	out = fastmorph.dilate(labels)
+	ans = np.ones((3,3), dtype=int, order="F")
+	ans[1:,:] = 2
+	assert np.all(ans == out)
+
+def test_multilabel_erode_3d():
 	labels = np.ones((3,3,3), dtype=bool)
 	out = fastmorph.erode(labels)
 	assert np.sum(out) == 1 and out[1,1,1] == True
@@ -146,6 +184,36 @@ def test_multilabel_erode():
 	labels = np.ones((5,5,5), dtype=bool)
 	out = fastmorph.erode(labels)
 	assert np.sum(out) == 27
+
+def test_multilabel_erode_2d():
+	labels = np.ones((3,3), dtype=bool)
+	out = fastmorph.erode(labels)
+	assert np.sum(out) == 1 and out[1,1] == True
+
+	out = fastmorph.erode(out)
+	assert not np.any(out)
+
+	out = fastmorph.erode(out)
+	assert not np.any(out)
+
+	labels = np.ones((3,3), dtype=int, order="F")
+	labels[0,:] = 1
+	labels[1,:] = 2
+	labels[2,:] = 3
+
+	out = fastmorph.erode(labels)
+	ans = np.zeros((3,3), dtype=int, order="F")
+
+	assert np.all(ans == out)
+
+	labels = np.zeros((5,5), dtype=bool)
+	labels[1:4,1:4] = True
+	out = fastmorph.erode(labels)
+	assert np.sum(out) == 1 and out[2,2] == True
+
+	labels = np.ones((5,5), dtype=bool)
+	out = fastmorph.erode(labels)
+	assert np.sum(out) == 9
 
 @pytest.mark.parametrize('dtype', [
 	np.uint8,np.uint16,np.uint32,np.uint64,

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -41,11 +41,15 @@ def dilate(
   parallel = min(parallel, mp.cpu_count())
 
   labels = np.asfortranarray(labels)
-  while labels.ndim < 3:
+  twoD = labels.ndim <= 2
+  while labels.ndim < 2:
     labels = labels[..., np.newaxis]
+  
   if mode == Mode.multilabel:
     output = fastmorphops.multilabel_dilate(labels, background_only, parallel)
   else:
+    if twoD:
+      raise NotImplementedError("2D grey dilate is not supported yet.")
     output = fastmorphops.grey_dilate(labels, parallel)
   return output.view(labels.dtype)
 
@@ -66,12 +70,15 @@ def erode(
   parallel = min(parallel, mp.cpu_count())
 
   labels = np.asfortranarray(labels)
-  while labels.ndim < 3:
+  twoD = labels.ndim <= 2
+  while labels.ndim < 2:
     labels = labels[..., np.newaxis]
 
   if mode == Mode.multilabel:
     output = fastmorphops.multilabel_erode(labels, parallel)
   else:
+    if twoD:
+      raise NotImplementedError("2D grey erode is not supported yet.")
     output = fastmorphops.grey_erode(labels, parallel)
   return output.view(labels.dtype)
 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -271,7 +271,7 @@ def fill_holes(
 
   if return_fill_count:
     for label in removed_set:
-      del fill_counts[label]
+      fill_counts.pop(label, None)
     ret.append(fill_counts)
 
   if return_removed:

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -41,15 +41,12 @@ def dilate(
   parallel = min(parallel, mp.cpu_count())
 
   labels = np.asfortranarray(labels)
-  twoD = labels.ndim <= 2
   while labels.ndim < 2:
     labels = labels[..., np.newaxis]
   
   if mode == Mode.multilabel:
     output = fastmorphops.multilabel_dilate(labels, background_only, parallel)
   else:
-    if twoD:
-      raise NotImplementedError("2D grey dilate is not supported yet.")
     output = fastmorphops.grey_dilate(labels, parallel)
   return output.view(labels.dtype)
 
@@ -70,15 +67,12 @@ def erode(
   parallel = min(parallel, mp.cpu_count())
 
   labels = np.asfortranarray(labels)
-  twoD = labels.ndim <= 2
   while labels.ndim < 2:
     labels = labels[..., np.newaxis]
 
   if mode == Mode.multilabel:
     output = fastmorphops.multilabel_erode(labels, parallel)
   else:
-    if twoD:
-      raise NotImplementedError("2D grey erode is not supported yet.")
     output = fastmorphops.grey_erode(labels, parallel)
   return output.view(labels.dtype)
 

--- a/fastmorph/fastmorph.hpp
+++ b/fastmorph/fastmorph.hpp
@@ -47,10 +47,10 @@ void parallelize_blocks(
 
 
 template <typename LABEL>
-void multilabel_dilate_3d(
+void multilabel_dilate(
 	LABEL* labels, LABEL* output,
 	const uint64_t sx, const uint64_t sy, const uint64_t sz,
-	const bool background_only, const uint64_t threads = 1
+	const bool background_only, const uint64_t threads
 ) {
 
 	// assume a 3x3x3 stencil with all voxels on
@@ -298,10 +298,10 @@ void multilabel_dilate_3d(
 }
 
 template <typename LABEL>
-void multilabel_dilate_2d(
+void multilabel_dilate(
 	LABEL* labels, LABEL* output,
 	const uint64_t sx, const uint64_t sy,
-	const bool background_only, const uint64_t threads = 1
+	const bool background_only, const uint64_t threads
 ) {
 
 	// assume a 3x3 stencil with all voxels on
@@ -465,7 +465,7 @@ void multilabel_dilate_2d(
 }
 
 template <typename LABEL>
-void multilabel_erode_3d(
+void multilabel_erode(
 	LABEL* labels, LABEL* output,
 	const uint64_t sx, const uint64_t sy, const uint64_t sz,
 	const uint64_t threads
@@ -619,7 +619,7 @@ void multilabel_erode_3d(
 }
 
 template <typename LABEL>
-void multilabel_erode_2d(
+void multilabel_erode(
 	LABEL* labels, LABEL* output,
 	const uint64_t sx, const uint64_t sy,
 	const uint64_t threads
@@ -722,10 +722,10 @@ void multilabel_erode_2d(
 }
 
 template <typename LABEL>
-void grey_dilate_3d(
+void grey_dilate(
 	LABEL* labels, LABEL* output,
 	const uint64_t sx, const uint64_t sy, const uint64_t sz,
-	const uint64_t threads = 1
+	const uint64_t threads
 ) {
 	// assume a 3x3x3 stencil with all voxels on
 	const uint64_t sxy = sx * sy;
@@ -860,10 +860,10 @@ void grey_dilate_3d(
 }
 
 template <typename LABEL>
-void grey_dilate_2d(
+void grey_dilate(
 	LABEL* labels, LABEL* output,
 	const uint64_t sx, const uint64_t sy,
-	const uint64_t threads = 1
+	const uint64_t threads
 ) {
 	// assume a 3x3 stencil with all voxels on
 	constexpr LABEL MAX_LABEL = std::numeric_limits<LABEL>::max();
@@ -976,7 +976,7 @@ void grey_dilate_2d(
 
 
 template <typename LABEL>
-void grey_erode_3d(
+void grey_erode(
 	LABEL* labels, LABEL* output,
 	const uint64_t sx, const uint64_t sy, const uint64_t sz,
 	const uint64_t threads
@@ -1115,7 +1115,7 @@ void grey_erode_3d(
 }
 
 template <typename LABEL>
-void grey_erode_2d(
+void grey_erode(
 	LABEL* labels, LABEL* output,
 	const uint64_t sx, const uint64_t sy,
 	const uint64_t threads

--- a/fastmorph/fastmorphops.cpp
+++ b/fastmorph/fastmorphops.cpp
@@ -109,7 +109,7 @@ py::array multilabel_dilate(
 	py::array output;
 
 #define DILATE_HELPER_3D(uintx_t)\
-	fastmorph::multilabel_dilate_3d(\
+	fastmorph::multilabel_dilate(\
 			reinterpret_cast<uintx_t*>(labels_ptr),\
 			reinterpret_cast<uintx_t*>(output_ptr),\
 			sx, sy, sz,\
@@ -118,7 +118,7 @@ py::array multilabel_dilate(
 		return to_numpy(reinterpret_cast<uintx_t*>(output_ptr), sx, sy, sz);
 
 #define DILATE_HELPER_2D(uintx_t)\
-	fastmorph::multilabel_dilate_2d(\
+	fastmorph::multilabel_dilate(\
 			reinterpret_cast<uintx_t*>(labels_ptr),\
 			reinterpret_cast<uintx_t*>(output_ptr),\
 			sx, sy,\
@@ -155,7 +155,7 @@ py::array multilabel_erode(const py::array &labels, const uint64_t threads) {
 	py::array output;
 
 #define ERODE_HELPER_3D(uintx_t)\
-	fastmorph::multilabel_erode_3d(\
+	fastmorph::multilabel_erode(\
 		reinterpret_cast<uintx_t*>(labels_ptr),\
 		reinterpret_cast<uintx_t*>(output_ptr),\
 		sx, sy, sz,\
@@ -164,7 +164,7 @@ py::array multilabel_erode(const py::array &labels, const uint64_t threads) {
 	return to_numpy(reinterpret_cast<uintx_t*>(output_ptr), sx, sy, sz);
 
 #define ERODE_HELPER_2D(uintx_t)\
-	fastmorph::multilabel_erode_2d(\
+	fastmorph::multilabel_erode(\
 		reinterpret_cast<uintx_t*>(labels_ptr),\
 		reinterpret_cast<uintx_t*>(output_ptr),\
 		sx, sy,\

--- a/fastmorph/fastmorphops.cpp
+++ b/fastmorph/fastmorphops.cpp
@@ -190,14 +190,16 @@ py::array grey_dilate(const py::array &labels, const uint64_t threads) {
 
 	const uint64_t sx = labels.shape()[0];
 	const uint64_t sy = labels.shape()[1];
-	const uint64_t sz = labels.shape()[2];
+	const uint64_t sz = labels.ndim() > 2 
+		? labels.shape()[2] 
+		: 1;
 
 	void* labels_ptr = const_cast<void*>(labels.data());
 	uint8_t* output_ptr = new uint8_t[sx * sy * sz * width]();
 
 	py::array output;
 
-#define GREY_DILATE_HELPER(int_t)\
+#define GREY_DILATE_HELPER_3D(int_t)\
 	fastmorph::grey_dilate(\
 		reinterpret_cast<int_t*>(labels_ptr),\
 		reinterpret_cast<int_t*>(output_ptr),\
@@ -206,9 +208,24 @@ py::array grey_dilate(const py::array &labels, const uint64_t threads) {
 	);\
 	return to_numpy(reinterpret_cast<int_t*>(output_ptr), sx, sy, sz);
 
-	DISPATCH_TO_TYPES(GREY_DILATE_HELPER)
+#define GREY_DILATE_HELPER_2D(int_t)\
+	fastmorph::grey_dilate(\
+		reinterpret_cast<int_t*>(labels_ptr),\
+		reinterpret_cast<int_t*>(output_ptr),\
+		sx, sy,\
+		threads\
+	);\
+	return to_numpy(reinterpret_cast<int_t*>(output_ptr), sx, sy);
 
-#undef GREY_DILATE_HELPER
+	if (labels.ndim() > 2) {
+		DISPATCH_TO_TYPES(GREY_DILATE_HELPER_3D)
+	}
+	else {
+		DISPATCH_TO_TYPES(GREY_DILATE_HELPER_2D)
+	}
+
+#undef GREY_DILATE_HELPER_3D
+#undef GREY_DILATE_HELPER_2D
 }
 
 // assumes fortran order
@@ -218,14 +235,16 @@ py::array grey_erode(const py::array &labels, const uint64_t threads) {
 
 	const uint64_t sx = labels.shape()[0];
 	const uint64_t sy = labels.shape()[1];
-	const uint64_t sz = labels.shape()[2];
+	const uint64_t sz = labels.ndim() > 2 
+		? labels.shape()[2] 
+		: 1;
 
 	void* labels_ptr = const_cast<void*>(labels.data());
 	uint8_t* output_ptr = new uint8_t[sx * sy * sz * width]();
 
 	py::array output;
 
-#define GREY_ERODE_HELPER(int_t)\
+#define GREY_ERODE_HELPER_3D(int_t)\
 	fastmorph::grey_erode(\
 		reinterpret_cast<int_t*>(labels_ptr),\
 		reinterpret_cast<int_t*>(output_ptr),\
@@ -234,9 +253,24 @@ py::array grey_erode(const py::array &labels, const uint64_t threads) {
 	);\
 	return to_numpy(reinterpret_cast<int_t*>(output_ptr), sx, sy, sz);
 
-	DISPATCH_TO_TYPES(GREY_ERODE_HELPER)
+#define GREY_ERODE_HELPER_2D(int_t)\
+	fastmorph::grey_erode(\
+		reinterpret_cast<int_t*>(labels_ptr),\
+		reinterpret_cast<int_t*>(output_ptr),\
+		sx, sy,\
+		threads\
+	);\
+	return to_numpy(reinterpret_cast<int_t*>(output_ptr), sx, sy);
 
-#undef GREY_ERODE_HELPER
+	if (labels.ndim() > 2) {
+		DISPATCH_TO_TYPES(GREY_ERODE_HELPER_3D)
+	}
+	else {
+		DISPATCH_TO_TYPES(GREY_ERODE_HELPER_2D)
+	}
+
+#undef GREY_ERODE_HELPER_3D
+#undef GREY_ERODE_HELPER_2D
 }
 
 #undef DISPATCH_TO_TYPES


### PR DESCRIPTION
This adds support for 2D images for dilate, erode, opening, and closing using 3x3 stencil for both multi-label and grey modes.