### PR TITLE
feat(erode): add erode_border option

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -200,6 +200,10 @@ def test_multilabel_erode_3d():
 	out = fastmorph.erode(labels)
 	assert np.sum(out) == 27
 
+	labels = np.ones((5,5,5), dtype=bool)
+	out = fastmorph.erode(labels, erode_border=False, iterations=5)
+	assert np.sum(out) == 125
+
 def test_multilabel_erode_2d():
 	labels = np.ones((3,3), dtype=bool)
 	out = fastmorph.erode(labels)

--- a/automated_test.py
+++ b/automated_test.py
@@ -230,6 +230,10 @@ def test_multilabel_erode_2d():
 	out = fastmorph.erode(labels)
 	assert np.sum(out) == 9
 
+	labels = np.ones((5,5), dtype=bool)
+	out = fastmorph.erode(labels, iterations=5, erode_border=False)
+	assert np.sum(out) == 25
+
 @pytest.mark.parametrize('dtype', [
 	np.uint8,np.uint16,np.uint32,np.uint64,
 	np.int8,np.int16,np.int32,np.int64,

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -87,6 +87,10 @@ def erode(
     Mode.grey: use grayscale image dilation (min value)
 
   iterations: number of times to iterate the result
+
+  erode_border: if True, the border is treated as background,
+    else it is regarded as a value that would preserve the
+    current value.
   """
   if iterations < 0:
     raise ValueError(f"iterations ({iterations}) must be a positive integer.")
@@ -118,6 +122,7 @@ def opening(
   parallel:int = 0,
   mode:Mode = Mode.multilabel,
   iterations:int = 1,
+  erode_border:bool = True,
 ) -> np.ndarray:
   """Performs morphological opening of labels.
 
@@ -125,9 +130,18 @@ def opening(
     True: Only evaluate background voxels for dilation.
     False: Allow labels to erode each other as they grow.
   parallel: how many pthreads to use in a threadpool
+  mode: 
+    Mode.multilabel: are all surrounding pixels the same?
+    Mode.grey: use grayscale image dilation (min value)
+
+  iterations: number of times to iterate the result
+
+  erode_border: if True, the border is treated as background,
+    else it is regarded as a value that would preserve the
+    current value.
   """
   return dilate(
-    erode(labels, parallel, mode, iterations),
+    erode(labels, parallel, mode, iterations, erode_border),
     background_only, parallel, mode, iterations
   )
 
@@ -137,6 +151,7 @@ def closing(
   parallel:int = 0,
   mode:Mode = Mode.multilabel,
   iterations:int = 1,
+  erode_border:bool = True,
 ) -> np.ndarray:
   """Performs morphological closing of labels.
 
@@ -144,10 +159,19 @@ def closing(
     True: Only evaluate background voxels for dilation.
     False: Allow labels to erode each other as they grow.
   parallel: how many pthreads to use in a threadpool
+  mode: 
+    Mode.multilabel: are all surrounding pixels the same?
+    Mode.grey: use grayscale image dilation (min value)
+
+  iterations: number of times to iterate the result
+
+  erode_border: if True, the border is treated as background,
+    else it is regarded as a value that would preserve the
+    current value.
   """
   return erode(
     dilate(labels, background_only, parallel, mode, iterations), 
-    parallel, mode, iterations
+    parallel, mode, iterations, erode_border,
   )
 
 def spherical_dilate(

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -90,7 +90,7 @@ def erode(
 
   erode_border: if True, the border is treated as background,
     else it is regarded as a value that would preserve the
-    current value.
+    current value. Only has an effect for multilabel erosion.
   """
   if iterations < 0:
     raise ValueError(f"iterations ({iterations}) must be a positive integer.")
@@ -138,7 +138,7 @@ def opening(
 
   erode_border: if True, the border is treated as background,
     else it is regarded as a value that would preserve the
-    current value.
+    current value. Only has an effect for multilabel erosion.
   """
   return dilate(
     erode(labels, parallel, mode, iterations, erode_border),
@@ -167,7 +167,7 @@ def closing(
 
   erode_border: if True, the border is treated as background,
     else it is regarded as a value that would preserve the
-    current value.
+    current value. Only has an effect for multilabel erosion.
   """
   return erode(
     dilate(labels, background_only, parallel, mode, iterations), 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -71,6 +71,7 @@ def erode(
   parallel:int = 0,
   mode:Mode = Mode.multilabel,
   iterations:int = 1,
+  erode_border:bool = True,
 ) -> np.ndarray:
   """
   Erodes forground labels using a 3x3x3 stencil with
@@ -105,7 +106,7 @@ def erode(
 
   for i in range(iterations):
     if mode == Mode.multilabel:
-      output = fastmorphops.multilabel_erode(output, parallel)
+      output = fastmorphops.multilabel_erode(output, erode_border, parallel)
     else:
       output = fastmorphops.grey_erode(output, parallel)
 

--- a/fastmorph/fastmorphops.cpp
+++ b/fastmorph/fastmorphops.cpp
@@ -179,10 +179,6 @@ py::array multilabel_erode(
 	return to_numpy(reinterpret_cast<uintx_t*>(output_ptr), sx, sy);
 
 	if (labels.ndim() > 2) {
-		if (erode_border == false) {
-			throw std::runtime_error("erode_border=false not supported for 3d.");
-		}
-
 		DISPATCH_TO_TYPES(ERODE_HELPER_3D)
 	}
 	else {

--- a/fastmorph/fastmorphops.cpp
+++ b/fastmorph/fastmorphops.cpp
@@ -139,7 +139,11 @@ py::array multilabel_dilate(
 }
 
 // assumes fortran order
-py::array multilabel_erode(const py::array &labels, const uint64_t threads) {
+py::array multilabel_erode(
+	const py::array &labels, 
+	const bool erode_border,
+	const uint64_t threads
+) {
 	py::dtype dt = labels.dtype();
 	int width = dt.itemsize();
 
@@ -159,6 +163,7 @@ py::array multilabel_erode(const py::array &labels, const uint64_t threads) {
 		reinterpret_cast<uintx_t*>(labels_ptr),\
 		reinterpret_cast<uintx_t*>(output_ptr),\
 		sx, sy, sz,\
+		erode_border,\
 		threads\
 	);\
 	return to_numpy(reinterpret_cast<uintx_t*>(output_ptr), sx, sy, sz);
@@ -168,11 +173,16 @@ py::array multilabel_erode(const py::array &labels, const uint64_t threads) {
 		reinterpret_cast<uintx_t*>(labels_ptr),\
 		reinterpret_cast<uintx_t*>(output_ptr),\
 		sx, sy,\
+		erode_border,\
 		threads\
 	);\
 	return to_numpy(reinterpret_cast<uintx_t*>(output_ptr), sx, sy);
 
 	if (labels.ndim() > 2) {
+		if (erode_border == false) {
+			throw std::runtime_error("erode_border=false not supported for 3d.");
+		}
+
 		DISPATCH_TO_TYPES(ERODE_HELPER_3D)
 	}
 	else {


### PR DESCRIPTION
If erode(..., erode_border=False), the part of the foreground touching the image border will not count towards erosion.