### PR TITLE
feat(fill_holes_v2): true multi-label fill holes

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v3.2.0
         # to supply options, put them in 'env', like:
         env:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pybind11 setuptools wheel crackle-codec 
+          python -m pip install pytest pybind11 setuptools wheel crackle-codec scipy
           python -m pip install connected-components-3d edt fastremap numpy tqdm fill-voids
 
       - name: Compile

--- a/automated_test.py
+++ b/automated_test.py
@@ -113,6 +113,11 @@ def test_complex_fill():
 	assert np.all(res == ans)
 
 def test_fill_holes_v2():
+	labels = np.zeros((10,10,10), dtype=np.uint64)
+	filled, holes = fastmorph.fill_holes_v2(labels)
+	assert not np.any(filled)
+	assert not np.any(holes)
+
 	labels = np.ones((10,10,10), dtype=np.uint8)
 	labels[:,:,:5] = 2
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -173,7 +173,7 @@ def test_fill_v2_fix_borders():
 		labels, 
 		fix_borders=True,
 	)
-	
+
 	assert np.all(filled == 1)
 	assert np.count_nonzero(holes) == 20*20*3
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -1,6 +1,9 @@
+import time
+
 import pytest
 import numpy as np
 import fastmorph
+import scipy.ndimage
 
 def test_spherical_dilate():
 	labels = np.zeros((10,10,10), dtype=bool)
@@ -108,6 +111,51 @@ def test_complex_fill():
 	)
 
 	assert np.all(res == ans)
+
+def test_fill_holes_v2():
+	labels = np.ones((10,10,10), dtype=np.uint8)
+	labels[:,:,:5] = 2
+
+	labels[5,5,2] = 0
+	labels[5,5,7] = 0
+
+	assert np.count_nonzero(labels) == 998
+	filled, holes = fastmorph.fill_holes_v2(labels)
+	assert np.count_nonzero(filled) == 1000
+	assert list(np.unique(filled)) == [1,2]
+
+	assert filled[5,5,2] == 2
+	assert filled[5,5,7] == 1
+
+	labels = np.ones((10,10,10), dtype=np.uint32)
+	labels[5,5,2] = 777
+
+	filled, holes = fastmorph.fill_holes_v2(labels, return_crackle=True)
+	assert set(holes.labels()) == set([0,777])
+
+	labels = np.ones((10,10,10), dtype=bool)
+	labels[5,5,2] = 0
+
+	res, holes = fastmorph.fill_holes_v2(labels)
+	assert np.all(res)
+	assert not np.any(holes)
+
+def test_fill_holes_v2_data():
+	import crackle
+	labels = crackle.load("connectomics.npy.ckl.gz")
+
+	s = time.time()
+	filled, holes = fastmorph.fill_holes_v2(labels)
+	print(f"{time.time() - s:.3f}")
+
+	uniq = np.unique(filled)
+	for lbl in uniq[:10]:
+		print(lbl)
+		if lbl == 0:
+			continue
+		binary_image_fm = filled == lbl
+		binary_image_scipy = scipy.ndimage.binary_fill_holes(labels == lbl)
+		assert np.all(binary_image_fm == binary_image_scipy)
 
 def test_spherical_open_close_run():
 	labels = np.zeros((10,10,10), dtype=bool)

--- a/automated_test.py
+++ b/automated_test.py
@@ -140,6 +140,38 @@ def test_fill_holes_v2():
 	assert np.all(res)
 	assert not np.any(holes)
 
+def test_fill_v2_fix_borders():
+	labels = np.ones([100,100,100], dtype=np.uint8)
+	labels[40:60,40:60,:] = 2
+	labels[40:60,:,40:60] = 2
+	labels[:,40:60,40:60] = 2
+
+	filled, holes = fastmorph.fill_holes_v2(
+		labels, 
+		fix_borders=False,
+	)
+	assert np.all(filled == labels)
+
+	filled, holes = fastmorph.fill_holes_v2(
+		labels, 
+		fix_borders=True,
+	)
+	assert np.all(filled == 1)
+	assert np.count_nonzero(holes) == 20*20*100*3 - 20*20*20*2
+
+	labels = np.ones([100,100,100], dtype=np.uint8)
+	labels[40:60,40:60,0] = 2
+	labels[40:60,0,40:60] = 2
+	labels[0,40:60,40:60] = 2
+
+	filled, holes = fastmorph.fill_holes_v2(
+		labels, 
+		fix_borders=True,
+	)
+	
+	assert np.all(filled == 1)
+	assert np.count_nonzero(holes) == 20*20*3
+
 def test_fill_holes_v2_data():
 	import crackle
 	labels = crackle.load("connectomics.npy.ckl.gz")

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -690,6 +690,9 @@ def fill_holes_v2(
 
   visited = np.zeros(N + 1, dtype=bool)
   for hole in list(holes):
+    if visited[hole]:
+      continue
+
     parent_label, group = _true_label(
       hole, edge_labels, 
       connections, surface_areas, 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -487,7 +487,7 @@ def _true_label(
 ) -> int:
   assert 0.0 <= merge_threshold <= 1.0
 
-  if hole in edges or merge_threshold == 0.0:
+  if hole in edges:
     return hole
 
   stack = [ hole ]

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -621,8 +621,9 @@ def fill_holes_v2(
   return_fill_count: return the total number of pixels filled in
     for boolean array: integer
     for integer array: { label: count }
-  fix_borders: along each edge of the image, consider labels that are totally
-    enclosed in 2d to be holes
+  fix_borders: along each edge of the image, try filling each label as a binary
+    image and consider labels removed to be holes and fill them. holes will be
+    returned without this filling artifact
   anisotropy: distortion along each axis, used for calculating contact surfaces
   merge_threshold: by default, only objects that are totally enclosed by a single
     label are considered holes, but sometimes they peek out slightly (e.g. an

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -564,6 +564,7 @@ def fill_holes_v2(
 
   Return value: (filled_labels, hole_labels)
   """
+  orig_dtype = labels.dtype
   if np.issubdtype(labels.dtype, bool):
     labels = labels.view(np.uint8)
 
@@ -660,9 +661,9 @@ def fill_holes_v2(
   remap = { k: orig_map[v] for k,v in remap.items()  }
 
   if HAS_CRACKLE:
-    filled_labels = cc_labels.remap(remap).astype(labels.dtype)
+    filled_labels = cc_labels.remap(remap).astype(orig_dtype)
     hole_labels = cc_labels.mask_except(list(holes))
-    hole_labels = hole_labels.remap(orig_map).astype(labels.dtype)
+    hole_labels = hole_labels.remap(orig_map).astype(orig_dtype)
 
     if return_crackle:
       return (filled_labels, hole_labels)
@@ -671,7 +672,7 @@ def fill_holes_v2(
   else:
     filled_labels = fastremap.remap(
       cc_labels, remap, in_place=False,
-    ).astype(labels.dtype, copy=False)
+    ).astype(orig_dtype, copy=False)
 
     hole_labels = fastremap.mask_except(cc_labels, list(holes))
     hole_labels = np.where(hole_labels, labels, 0)

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -631,11 +631,8 @@ def fill_holes_v2(
       connectivity=6,
     )
 
-  sentinel = np.iinfo(labels.dtype).max
-
   orig_map = fastremap.component_map(cc_labels, labels)
   orig_map[0] = 0
-  orig_map[sentinel] = sentinel
 
   surface_areas = cc3d.contacts(
     cc_labels, 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -477,11 +477,20 @@ def fill_holes_v2(
   import crackle
 
   # Ensure bg 0 gets treated as a connected component
-  cc_labels, N = cc3d.connected_components(
-    labels + 1, 
-    return_N=True, 
-    connectivity=26,
-  )
+  if labels.flags.writeable:
+    labels += 1
+    cc_labels, N = cc3d.connected_components(
+      labels, 
+      return_N=True, 
+      connectivity=26,
+    )
+    labels -= 1
+  else:
+    cc_labels, N = cc3d.connected_components(
+      labels + 1, 
+      return_N=True, 
+      connectivity=26,
+    )
 
   sentinel = np.iinfo(labels.dtype).max
 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -564,6 +564,8 @@ def fill_holes_v2(
 
   Return value: (filled_labels, hole_labels)
   """
+  if np.issubdtype(labels.dtype, bool):
+    labels = labels.view(np.uint8)
 
   # Ensure bg 0 gets treated as a connected component
   if labels.flags.writeable:

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -534,7 +534,7 @@ def fill_holes_v2(
   holes = candidate_holes.difference(edge_labels)
   del candidate_holes
 
-  def best_contact(edges):
+  def best_contact(segid, edges):
     if not len(edges):
       return sentinel
 
@@ -548,7 +548,7 @@ def fill_holes_v2(
       if len(contact_surfaces) == 1:
         return contact_surfaces[0][0]
       else:
-        return 0
+        return segid
 
     contact_surfaces.sort(key=lambda x: x[1])
     max_contact, max_area = contact_surfaces[-1]
@@ -557,18 +557,18 @@ def fill_holes_v2(
     if max_area >= merge_threshold:
       return max_contact
     else:
-      return 0
+      return segid
 
   remap = { i:i for i in range(N+1) }
 
-  for hole in holes:
+  for hole in list(holes):
     if len(connections[hole]):
       edges = connections[hole].intersection(edge_labels)
       if not len(edges):
         edges = connections[hole]
-      remap[hole] = best_contact(edges)
+      remap[hole] = best_contact(hole, edges)
     else:
-      remap[hole] = 0
+      holes.discard(hole)
 
   del connections
   del edge_labels

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -22,7 +22,7 @@ from tqdm import trange
 
 import fastmorphops
 
-AnisotropyType = Optional[Iterator[int]]
+AnisotropyType = Optional[Iterator[float]]
 
 class Mode(Enum):
   multilabel = 1
@@ -581,7 +581,7 @@ def fill_holes_v2(
   labels:npt.NDArray[np.number],
   fix_borders:bool = False,
   merge_threshold:float = 1.0,
-  anisotropy:tuple[float,float,float] = (1.0, 1.0, 1.0),
+  anisotropy:AnisotropyType = (1.0, 1.0, 1.0),
   parallel:int = 0,
   return_crackle:bool = False,
 ) -> Union[

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -525,7 +525,8 @@ def fill_holes_v2(
 
   for bgl in bg_edge_labels:
     for lbl in connections[bgl]:
-      edge_labels.add(lbl)
+      if surface_areas[tuple(sorted([bgl, lbl]))] > 0:
+        edge_labels.add(lbl)
 
   del uniq
   del slice_labels

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -518,7 +518,7 @@ def _true_label(
     areas = defaultdict(int)
     total_area = 0
 
-    if len(hole_group) * len(found_edges) < len(connections):
+    if len(hole_group) * len(found_edges) < len(surface_areas):
       for edge in found_edges:
         for hole_i in hole_group:
           area = surface_areas.get(tuple(sorted([edge, hole_i])), 0)

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -428,6 +428,8 @@ def fill_holes(
 
   return (ret[0] if len(ret) == 1 else tuple(ret))
 
+fill_holes_v1 = fill_holes
+
 def _pairs_to_connection_list(itr):
   tmp = defaultdict(set)
   for l1, l2 in itr:

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -612,12 +612,12 @@ def fill_holes_v2(
     slice_labels = cc_labels[slc]
     uniq = set(fastremap.unique(slice_labels))
 
+    if fix_borders:
+      uniq -= _fix_holes_2d(slice_labels, merge_threshold)
+
     for u in uniq:
       if orig_map[u] == 0:
         bg_edge_labels.add(u)
-
-    if fix_borders:
-      uniq -= _fix_holes_2d(slice_labels, merge_threshold)
 
     edge_labels.update(uniq)
 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -423,8 +423,17 @@ def fill_holes(
 @profile
 def fill_holes_multilabel(
   labels:np.ndarray, 
-  anisotropy:tuple[float,float,float] = (1.0,1.0,1.0)
+  anisotropy:tuple[float,float,float] = (1.0,1.0,1.0),
+  morphological_closing:bool = False,
 ) -> tuple[np.ndarray, set[int]]:
+
+  if morphological_closing:
+    labels = closing(
+      labels, 
+      mode=Mode.multilabel, 
+      background_only=True, 
+      erode_border=False
+    )
 
   # Ensure bg 0 gets treated as a connected component
   labels += 1

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -493,11 +493,8 @@ def _true_label(
   found_edges = set()
   hole_group = set()
 
-  x = False
   while stack:
     label = stack.pop()
-    if label == 643: 
-      x = True
 
     if label in edges:
       found_edges.add(label)
@@ -559,14 +556,14 @@ def fill_holes_v2(
     cc_labels, N = cc3d.connected_components(
       labels, 
       return_N=True, 
-      connectivity=26,
+      connectivity=6,
     )
     labels -= 1
   else:
     cc_labels, N = cc3d.connected_components(
       labels + 1, 
       return_N=True, 
-      connectivity=26,
+      connectivity=6,
     )
 
   sentinel = np.iinfo(labels.dtype).max
@@ -577,7 +574,7 @@ def fill_holes_v2(
 
   surface_areas = cc3d.contacts(
     cc_labels, 
-    connectivity=26, 
+    connectivity=6, 
     surface_area=True, 
     anisotropy=tuple(anisotropy),
   )

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -431,7 +431,7 @@ def fill_holes(
 
 fill_holes_v1 = fill_holes
 
-def _pairs_to_connection_list(itr):
+def _pairs_to_connection_list(itr:Iterator[tuple[int,int]]) -> defaultdict[set[int]]:
   tmp = defaultdict(set)
   for l1, l2 in itr:
     tmp[l1].add(l2)
@@ -549,11 +549,14 @@ def _true_label(
   return hole, hole_group
 
 def _fill_binary_image(
-  binary_image:np.ndarray,
+  binary_image:npt.NDArray[np.bool_],
   fix_borders:bool,
   return_crackle:bool,
   parallel:int,
-):
+) -> Union[
+  tuple[npt.NDArray[np.bool_], npt.NDArray[np.bool_]],
+  tuple["CrackleArray", "CrackleArray"]
+]:
   if fix_borders:
     binary_image[:,:,0] = fill_voids.fill(binary_image[:,:,0])
     binary_image[:,:,-1] = fill_voids.fill(binary_image[:,:,-1])
@@ -575,13 +578,16 @@ def _fill_binary_image(
   return binary_image, np.zeros(binary_image.shape, dtype=bool, order=order)
 
 def fill_holes_v2(
-  labels:np.ndarray,
+  labels:npt.NDArray[np.number],
   fix_borders:bool = False,
   merge_threshold:float = 1.0,
   anisotropy:tuple[float,float,float] = (1.0, 1.0, 1.0),
   parallel:int = 0,
   return_crackle:bool = False,
-) -> Union[tuple[np.ndarray, np.ndarray], tuple["CrackleArray", "CrackleArray"]]:
+) -> Union[
+  tuple[npt.NDArray[np.number], npt.NDArray[np.number]], 
+  tuple["CrackleArray", "CrackleArray"]
+]:
   """
   For filling holes in toplogically closed objects using a faster method
   for multilabel objects.

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -463,6 +463,7 @@ def fill_holes_multilabel(
     holes2d = []
     for segid, neighbors in connections2d.items():
       neighbors.discard(0)
+      neighbors = [ n for n in neighbors if sa[tuple(sorted([ segid, n ]))] > 7 ]
       if len(neighbors) == 1:
         holes2d.append(segid)
 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -700,6 +700,7 @@ def fill_holes_v2(
     )
     if hole == parent_label:
       holes.discard(hole)
+      holes.difference_update(group)
       continue
 
     for hole_i in group:

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -451,7 +451,7 @@ def _fill_holes_2d(
     return_N=True,
   )
 
-  if N == 1:
+  if N <= 1:
     return slice_labels, set()
 
   orig_map = fastremap.component_map(cc_labels, slice_labels)

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -458,9 +458,7 @@ def _fill_holes_2d(
   sublabels = set()
 
   for segid in range(1,N):
-    if segid == 0:
-      continue
-    elif segid in sublabels:
+    if segid in sublabels:
       continue
     
     slc = bboxes[segid]

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -423,21 +423,10 @@ def fill_holes(
 def fill_holes_multilabel(
   labels:np.ndarray, 
   anisotropy:tuple[float,float,float] = (1.0,1.0,1.0),
-  morphological_closing:bool = False,
 ) -> tuple[np.ndarray, set[int]]:
 
-  if morphological_closing:
-    labels = closing(
-      labels, 
-      mode=Mode.multilabel, 
-      background_only=True, 
-      erode_border=False
-    )
-
   # Ensure bg 0 gets treated as a connected component
-  labels += 1
-  cc_labels, N = cc3d.connected_components(labels, return_N=True, connectivity=26)
-  labels -= 1
+  cc_labels, N = cc3d.connected_components(labels + 1, return_N=True, connectivity=26)
 
   surface_areas = cc3d.contacts(
     cc_labels, 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Iterator
 
 from collections import defaultdict
 from enum import Enum
@@ -21,7 +21,7 @@ from tqdm import trange
 
 import fastmorphops
 
-AnisotropyType = Optional[Sequence[int]]
+AnisotropyType = Optional[Iterator[int]]
 
 class Mode(Enum):
   multilabel = 1

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -513,12 +513,12 @@ def _true_label(
       stack.append(next_label)
 
   if merge_threshold < 1.0:
-    areas = {}
+    areas = defaultdict(int)
     total_area = 0
 
     for edge in found_edges:
       for hole_i in hole_group:
-        area = surface_areas[tuple(sorted([edge, hole_i]))]
+        area = surface_areas.get(tuple(sorted([edge, hole_i])), 0)
         areas[edge] += area
         total_area += area
 
@@ -639,7 +639,7 @@ def fill_holes_v2(
   remap = { i:i for i in range(N+1) }
 
   visited = np.zeros(len(connections) + 1, dtype=bool)
-  for hole in tqdm(list(holes)):
+  for hole in list(holes):
     parent_label, group = _true_label(
       hole, edge_labels, 
       connections, surface_areas, 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -663,8 +663,6 @@ def fill_holes_v2(
         continue
 
       for hole_i in group:
-        if hole_i == 643 or parent_label == 643:
-          import pdb; pdb.set_trace()
         remap[hole_i] = parent_label
   else:
     for hole in list(holes):

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -518,9 +518,24 @@ def _true_label(
     areas = defaultdict(int)
     total_area = 0
 
-    for edge in found_edges:
-      for hole_i in hole_group:
-        area = surface_areas.get(tuple(sorted([edge, hole_i])), 0)
+    if len(hole_group) * len(found_edges) < len(connections):
+      for edge in found_edges:
+        for hole_i in hole_group:
+          area = surface_areas.get(tuple(sorted([edge, hole_i])), 0)
+          areas[edge] += area
+          total_area += area
+    else:
+      subset = [ 
+        pair for pair in surface_areas.keys() 
+        if (
+          (pair[0] in hole_group and pair[1] in found_edges)
+          or (pair[1] in hole_group and pair[0] in found_edges)
+        )
+      ]
+
+      for pair in subset:
+        area = surface_areas[pair]
+        edge = pair[0] if pair[0] in found_edges else pair[1]
         areas[edge] += area
         total_area += area
 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -569,13 +569,33 @@ def fill_holes_v2(
   For filling holes in toplogically closed objects using a faster method
   for multilabel objects.
 
+  Base Mulit-Label Fill Algorithm:
+
+    1. Color all 6-connected components (even background)
+    2. Compute surface area of adjacent regions (6-connected)
+    3. Compute connection list { label: [neighbor labels], ... }
+    4. Create a set of candidate holes from all connected components
+      and then filter them by the set difference with labels touching
+      the edges of the cutout.
+        - To account for e.g. a foreground object surrounded by 
+          background, also label as edges all objects touching
+          background that touches the image border.
+    5. For each hole, walk through the region graph to identify 
+      all neighboring holes and edges. 
+    6. If there is more than one edge label, do nothing. If 
+      there is only one edge label, all the neighboring holes
+      are part of a hole group, label them with that edge label.
+
+  For boolean images, simply use the fill_voids algorithm since
+  that is faster.
+
   NOTE: if crackle-codec is installed, this function will have reduced memory usage.
 
   return_fill_count: return the total number of pixels filled in
     for boolean array: integer
     for integer array: { label: count }
   fix_borders: along each edge of the image, consider labels that are totally
-    enclosed to be holes
+    enclosed in 2d to be holes
   anisotropy: distortion along each axis, used for calculating contact surfaces
   merge_threshold: by default, only objects that are totally enclosed by a single
     label are considered holes, but sometimes they peek out slightly (e.g. an

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -458,7 +458,7 @@ def fill_holes_multilabel(
 
   for slc in slices:
     slice_labels = cc_labels[slc]
-    sa = cc3d.contacts(slice_labels, connectivity=8)
+    sa = cc3d.contacts(slice_labels, connectivity=4)
     connections2d = pairs_to_connection_list(sa.keys())
     holes2d = []
     for segid, neighbors in connections2d.items():

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -450,6 +450,10 @@ def _fill_holes_2d(
     connectivity=4,
     return_N=True,
   )
+
+  if N == 1:
+    return slice_labels, set()
+
   orig_map = fastremap.component_map(cc_labels, slice_labels)
 
   stats = cc3d.statistics(cc_labels)

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -633,6 +633,9 @@ def fill_holes_v2(
 
   Return value: (filled_labels, hole_labels)
   """
+  if not HAS_CRACKLE and return_crackle:
+    raise ImportError("crackle not found. Try pip install crackle-codec or set return_crackle=False")
+
   if np.issubdtype(labels.dtype, bool):
     # This is for speed, not because the below code is incorrect for bool
     # merge_threshold does nothing for a binary image anyway, so ignore it.

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -284,7 +284,7 @@ def fill_holes(
   parallel:int = 0,
 ) -> np.ndarray:
   """
-  For fill holes in toplogically closed objects.
+  For filling holes in toplogically closed objects.
 
   return_fill_count: return the total number of pixels filled in
     for boolean array: integer
@@ -483,6 +483,32 @@ def fill_holes_v2(
   parallel:int = 0,
   return_crackle:bool = False,
 ) -> Union[tuple[np.ndarray, np.ndarray], tuple["CrackleArray", "CrackleArray"]]:
+  """
+  For filling holes in toplogically closed objects using a faster method
+  for multilabel objects.
+
+  NOTE: if crackle-codec is installed, this function will have reduced memory usage.
+
+  return_fill_count: return the total number of pixels filled in
+    for boolean array: integer
+    for integer array: { label: count }
+  fix_borders: along each edge of the image, consider labels that are totally
+    enclosed to be holes
+  anisotropy: distortion along each axis, used for calculating contact surfaces
+  merge_threshold: by default, only objects that are totally enclosed by a single
+    label are considered holes, but sometimes they peek out slightly (e.g. an
+    organelle touching the membrane of a cell). You can set merge_threshold from
+    0.0 to 1.0. This is the fraction of surface area that must be enclosed by a 
+    single label to be considered mergable. You probably want this to be set
+    above 0.85 at the outside (more likely above 0.95). Set it too low, and you'll 
+    introduce external mergers.
+  parallel: pass this value to any internal algorithms that support parallel operation
+  return_crackle: you can reduce memory usage by returning the outputs as compressed
+    CrackleArrays.
+
+  Return value: (filled_labels, hole_labels)
+  """
+
   # Ensure bg 0 gets treated as a connected component
   if labels.flags.writeable:
     labels += 1

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -486,9 +486,6 @@ def _true_label(
 ) -> int:
   # assert 0.0 <= merge_threshold <= 1.0
 
-  if hole == 643:
-    import pdb; pdb.set_trace()
-
   if hole in edges:
     return hole
 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -420,7 +420,6 @@ def fill_holes(
 
   return (ret[0] if len(ret) == 1 else tuple(ret))
 
-@profile
 def fill_holes_multilabel(
   labels:np.ndarray, 
   anisotropy:tuple[float,float,float] = (1.0,1.0,1.0),

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -512,7 +512,7 @@ def _true_label(
     for next_label in connections[label]:
       stack.append(next_label)
 
-  if merge_threshold < 1.0:
+  if merge_threshold > 0.0 and len(found_edges) > 1:
     areas = defaultdict(int)
     total_area = 0
 

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -745,6 +745,8 @@ def fill_holes_v2(
   if HAS_CRACKLE:
     filled_labels = cc_labels.remap(remap).astype(labels.dtype)
     del cc_labels
+    del remap
+
     hole_labels = orig_cc_labels.mask_except(list(holes))
     hole_labels = hole_labels.remap(orig_map).astype(labels.dtype)
 
@@ -757,6 +759,7 @@ def fill_holes_v2(
       cc_labels, remap, in_place=False,
     ).astype(labels.dtype, copy=False)
     del cc_labels
+    del remap
 
     hole_labels = fastremap.mask_except(orig_cc_labels, list(holes), in_place=True)
     hole_labels = np.where(hole_labels, labels, 0).astype(labels.dtype, copy=False)

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -486,11 +486,11 @@ def _true_label(
   surface_areas:dict[tuple[int,int],float],
   merge_threshold:float,
   visited:np.ndarray,
-) -> int:
+) -> tuple[int, set[int]]:
   assert 0.0 <= merge_threshold <= 1.0
 
   if hole in edges:
-    return hole
+    return hole, set()
 
   stack = [ hole ]
   found_edges = set()

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -590,13 +590,10 @@ def fill_holes_v2(
 
   Return value: (filled_labels, hole_labels)
   """
-  orig_dtype = labels.dtype
   if np.issubdtype(labels.dtype, bool):
     # This is for speed, not because the below code is incorrect for bool
     # merge_threshold does nothing for a binary image anyway, so ignore it.
     return _fill_binary_image(labels, fix_borders, return_crackle, parallel)
-
-    labels = labels.view(np.uint8)
 
   # Ensure bg 0 gets treated as a connected component
   if labels.flags.writeable:
@@ -691,9 +688,9 @@ def fill_holes_v2(
   remap = { k: orig_map[v] for k,v in remap.items()  }
 
   if HAS_CRACKLE:
-    filled_labels = cc_labels.remap(remap).astype(orig_dtype)
+    filled_labels = cc_labels.remap(remap).astype(labels.dtype)
     hole_labels = cc_labels.mask_except(list(holes))
-    hole_labels = hole_labels.remap(orig_map).astype(orig_dtype)
+    hole_labels = hole_labels.remap(orig_map).astype(labels.dtype)
 
     if return_crackle:
       return (filled_labels, hole_labels)
@@ -702,7 +699,7 @@ def fill_holes_v2(
   else:
     filled_labels = fastremap.remap(
       cc_labels, remap, in_place=False,
-    ).astype(orig_dtype, copy=False)
+    ).astype(labels.dtype, copy=False)
 
     hole_labels = fastremap.mask_except(cc_labels, list(holes))
     hole_labels = np.where(hole_labels, labels, 0)

--- a/fastmorph/__init__.py
+++ b/fastmorph/__init__.py
@@ -462,11 +462,14 @@ def _fill_holes_2d(
       continue
     elif segid in sublabels:
       continue
-    elif zero_map[orig_map[segid]] == 0:
-      continue
-
+    
     slc = bboxes[segid]
     binary_image = cc_labels[slc] == segid
+    
+    if zero_map[orig_map[segid]] == 0:
+      output[slc][binary_image] = orig_map[segid]
+      continue
+    
     binary_image = fill_voids.fill(binary_image)
 
     enclosed = set(fastremap.unique(cc_labels[slc][binary_image]))

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 crackle-codec
 wheel
+scipy
 twine 


### PR DESCRIPTION
A new implementation of fill_holes that finally treats fill_holes as a multi-label problem, accelerating hole filling one to two orders of magnitude. The problem this is attempting to solve is performing hole filling on an 813^3 u64 image could take multiple hours (doing it on a 513^2 image could take minutes to ~20 minutes). This new implementation can perform hole filling in seconds to about a minute.

One difference is that this implementation always returns an array of filled and holes whereas the original version would return filled and possible a fill count and a set of hole labels in the interests of memory efficiency. However, with the advent of crackle compressed arrays, concerns about memory usage can be dispensed with.

```python
filled_labels, hole_labels = fastmorph.fill_holes_v2(labels, return_crackle=True)

filled_labels, holes = fastmorph.fill_holes_v1(labels, remove_enclosed=True, return_removed=True)
```

v2 also supports `fix_borders` like v1. Where v1 has `morphological_closing` which applies a dilation then an erosion after hole filling, which can change the contours of labels, v2 has a `merge_threshold` between 0.0 to 1.0. The `merge_threshold` is the necessary ratio of the contact surface of a label over all contact surfaces to assign a parent label. 1.0 = only one parent is acceptable (same as standard hole filling). As `merge_threshold` decreases from 1, holes that poke just through the surface (e.g. an organelle that brushes against the plasma membrane) can be merged into the parent label. This strategy has the advantage of not altering the shape of the base labels as well as being faster.

The fill_holes_v2 interface is different, so to preserve backwards compatibility, we'll keep both for now with `fill_holes` and `fill_holes_v1` aliases of each other.